### PR TITLE
Enabled AutoSize on the forms

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -66,6 +66,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(379, 67);
             this.Controls.Add(this.actionOkBtn);
             this.Controls.Add(this.actionComboBox);

--- a/SelectForm.Designer.cs
+++ b/SelectForm.Designer.cs
@@ -63,6 +63,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(358, 83);
             this.ControlBox = false;
             this.Controls.Add(this.selectComboBox);

--- a/TransferForm.Designer.cs
+++ b/TransferForm.Designer.cs
@@ -95,6 +95,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(380, 106);
             this.ControlBox = false;
             this.Controls.Add(this.dstComboBox);


### PR DESCRIPTION
...so that the buttons show correctly if the user has custom scaling on their display. Previously the buttons were hidden like [this](https://i.imgur.com/QA7eDm4.png).